### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuousintegration.yml
+++ b/.github/workflows/continuousintegration.yml
@@ -4,6 +4,8 @@ on:
         branches:
             -   main
 
+permissions:
+    contents: read
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MatheusKozakk/curly-fortnight/security/code-scanning/8](https://github.com/MatheusKozakk/curly-fortnight/security/code-scanning/8)

To fix this issue, add a `permissions:` block specifying the least privilege needed for the workflow’s jobs. The best location is either at the workflow root (before `jobs:`), or at the individual job level (under `build:`). Given the jobs shown only require contents to be read (for checking out code and running a linter), set `contents: read`. Edit `.github/workflows/continuousintegration.yml` to add:

```yaml
permissions:
  contents: read
```

Add this right after the `name:` or the `on:` block at the top, so it applies to the whole workflow. No new imports or special definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
