### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuousdelivery.yml
+++ b/.github/workflows/continuousdelivery.yml
@@ -1,4 +1,6 @@
 name: Continuous Delivery
+permissions:
+    contents: read
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/MatheusKozakk/curly-fortnight/security/code-scanning/7](https://github.com/MatheusKozakk/curly-fortnight/security/code-scanning/7)

The best way to fix this is to explicitly set the `permissions:` key for the workflow. This can be done either at the top level of the workflow (applies to all jobs) or inside the specific job (`deliver`). Given that there is only one job, both approaches are valid, but the standard is to add it at the top level for clarity and global enforcement. The recommended minimal starting point is:

```yaml
permissions:
  contents: read
```

This grants read-only access to repository contents via the GITHUB_TOKEN, which is sufficient for typical actions like checkout, unless a step requires more permission (e.g., writing issues, deploying). The artifact upload action itself does not require write access to repository contents. The change should be made at the top level, after the workflow `name:` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
